### PR TITLE
Respect dateSolutionAvailable field

### DIFF
--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -698,7 +698,7 @@ class Crossword extends Component {
   }
 
   hasSolutions() {
-    const dateSolutionAvailable = this.props.data.dateSolutionAvailable;
+    const { dateSolutionAvailable } = this.props.data;
     const timeNow = new Date().getTime();
     const solutionShouldBeAvailable =
       !dateSolutionAvailable || dateSolutionAvailable < timeNow;

--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -698,7 +698,12 @@ class Crossword extends Component {
   }
 
   hasSolutions() {
-    return 'solution' in this.props.data.entries[0];
+    const dateSolutionAvailable = this.props.data.dateSolutionAvailable;
+    const timeNow = new Date().getTime();
+    const solutionShouldBeAvailable =
+      !dateSolutionAvailable || dateSolutionAvailable < timeNow;
+    const solutionExists = "solution" in this.props.data.entries[0]
+    return solutionExists && solutionShouldBeAvailable
   }
 
   isHighlighted(x, y) {


### PR DESCRIPTION
Some guardian crosswords should only reveal the answers after a week has passed. Typically we enforce this on the server side but for some applications the crosswords are 'frozen' on the day of publication and can't be updated one week later with the new version with the solutions. This change gets react-crossword to respect dateSolutionAvailable - and hide the 'reveal all' button when that date has not yet passed.