### PR TITLE
Am increase instructions font size

### DIFF
--- a/src/stylesheets/crosswords/_clues.scss
+++ b/src/stylesheets/crosswords/_clues.scss
@@ -1,7 +1,6 @@
 .crossword__instructions {
     font-family: $f-sans-serif-text;
-    font-size: 15px;
-    line-height: 18px;
+    @include fs-textSans(4);
     width: 100%;
     clear: both;
 

--- a/src/stylesheets/crosswords/_clues.scss
+++ b/src/stylesheets/crosswords/_clues.scss
@@ -1,6 +1,6 @@
 .crossword__instructions {
     font-family: $f-sans-serif-text;
-    @include fs-textSans(4);
+    @include fs-textSans(5);
     width: 100%;
     clear: both;
 


### PR DESCRIPTION
## What does this change?
As requested by design the special instructions should appear larger than the clues. This updates the font size, see screenshots. 
| Before | After |
| --- | --- |
![Simulator Screen Shot - iPhone 11 - 2020-07-09 at 14 42 47](https://user-images.githubusercontent.com/53755195/87067492-06efdb00-c20c-11ea-90ce-e739082d2459.png) | ![Simulator Screen Shot - iPhone 11 - 2020-07-09 at 17 19 14](https://user-images.githubusercontent.com/53755195/87067439-f17ab100-c20b-11ea-84a8-01f7e21a2f60.png)
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## What is the cost of failure?
<!-- Is this a critical path? Does failure costs money, violates law, ruins reputation? Do we need to alarm on failure? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
