### PR TITLE
Revert-hide-solutions

### DIFF
--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -699,12 +699,7 @@ class Crossword extends Component {
   }
 
   hasSolutions() {
-    const { dateSolutionAvailable } = this.props.data;
-    const timeNow = new Date().getTime();
-    const solutionShouldBeAvailable =
-      !dateSolutionAvailable || dateSolutionAvailable < timeNow;
-    const solutionExists = "solution" in this.props.data.entries[0]
-    return solutionExists && solutionShouldBeAvailable
+    return 'solution' in this.props.data.entries[0];
   }
 
   isHighlighted(x, y) {


### PR DESCRIPTION
## What does this change?
This PR reverts https://github.com/guardian/react-crossword/pull/2 which was merged but didn't fully work. We hadn't published a version of the crosswords since this change was merged and so only now can see it is hiding the `Check all` and `Reveal all` buttons which is undesired. 
You should now see those buttons are present when viewing crosswords. 
![Simulator Screen Shot - iPhone 11 - 2020-07-13 at 09 18 17](https://user-images.githubusercontent.com/53755195/87334770-125a4380-c537-11ea-9122-796c80f8ec7b.png)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
