### PR TITLE
Move the project to `guardian-mobile` Snyk org

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,7 +15,7 @@ jobs:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       DEBUG: true
-      ORG: guardian-dotcom-n2y
+      ORG: guardian-mobile
       SKIP_NODE: false
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
It is currently in the `guardian-dotcom-n2y` org but the project is only used in `editions`: https://github.com/search?q=org%3Aguardian+react-crossword&type=code

