### PR TITLE
release pipeline: build before publish

### DIFF
--- a/.changeset/cold-bulldogs-invent.md
+++ b/.changeset/cold-bulldogs-invent.md
@@ -1,0 +1,5 @@
+---
+"@guardian/react-crossword": minor
+---
+
+Run build script before publishing

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,11 +29,13 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
+      - name: Build
+        run: yarn build
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
-          # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Publishing is working, but no js files are being included in the package. This is because the workflow doesn't build before it publishes, so delivers an empty package to npm.

## How to test

Not sure how to test with changesets; there aren't many (any?) external consumers so probably best to test by releasing and seeing if the published package is usable

## How can we measure success?

Usable published packages
