### PR TITLE
Fix SVG import and ref usage

### DIFF
--- a/.changeset/wicked-melons-happen.md
+++ b/.changeset/wicked-melons-happen.md
@@ -1,0 +1,5 @@
+---
+"@guardian/react-crossword": patch
+---
+
+Fix SVG import and ref usage

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-react": "^7.22.15",
     "@changesets/cli": "^2.26.2",
+    "@parcel/transformer-inline-string": "2.10.0",
     "@parcel/transformer-sass": "2.10.0",
     "babel-jest": "^29.7.0",
     "chance": "1.1.11",

--- a/src/javascripts/crosswords/anagram-helper/main.js
+++ b/src/javascripts/crosswords/anagram-helper/main.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import shuffle from 'lodash/shuffle';
-import closeCentralIcon from '../../../svgs/close.svg';
+import closeCentralIcon from 'bundle-text:../../../svgs/close.svg';
 import { cellsForClue, getAnagramClueData } from '../helpers';
 import { ClueInput } from './clue-input';
 import { CluePreview } from './clue-preview';

--- a/src/javascripts/crosswords/clues.js
+++ b/src/javascripts/crosswords/clues.js
@@ -46,7 +46,7 @@ class Clues extends Component {
     this.state = {
       showGradient: true,
     };
-    this.cluesRef = createRef(this.clues);
+    this.cluesRef = createRef();
   }
 
   componentDidMount() {
@@ -127,9 +127,7 @@ class Clues extends Component {
       >
         <div
           className="crossword__clues"
-          ref={(clues) => {
-            this.clues = clues;
-          }}
+          ref={this.cluesRef}
         >
           <div className="crossword__clues--across">
             <h3 className={headerClass}>Across</h3>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2126,6 +2126,13 @@
     "@parcel/workers" "2.10.0"
     nullthrows "^1.1.1"
 
+"@parcel/transformer-inline-string@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-inline-string/-/transformer-inline-string-2.10.0.tgz#9681188484feb8d3b0f00d0e548348929bab3a48"
+  integrity sha512-MBrQgcKZXZuHlo9cVwl1+GyWpaQLAPKAswNu8KCxmzEL1bpCk9qyG+HahVGgBW+LncBP029op+9h5KLjkQtZ3A==
+  dependencies:
+    "@parcel/plugin" "2.10.0"
+
 "@parcel/transformer-js@2.10.0":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@parcel/transformer-js/-/transformer-js-2.10.0.tgz#142a70b77466e5359774d21939da06d5f579bb5e"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Since v1.2.0, a couple of bugs have crept in:
- The usage of a created ref was mixed with a callback ref (https://legacy.reactjs.org/docs/refs-and-the-dom.html) which didn't work; I've updated it to be a "plain" ref
- The parcel default was to load the imported SVG as a file from the filesystem - which doesn't work when the bundled JS is running in a browser! I've updated it to use "bundle-text" (https://parceljs.org/features/bundle-inlining/) which loads the svg as bundle time, and stores as a string inside the bundled JS, so loading works as expected in the browser.

## How to test

The example page should now run

