### PR TITLE
Support quick cryptic crosswords

### DIFF
--- a/.changeset/five-fireants-cry.md
+++ b/.changeset/five-fireants-cry.md
@@ -1,0 +1,5 @@
+---
+"@guardian/react-crossword": patch
+---
+
+add quick-cryptic grid size value

--- a/.changeset/long-cups-bow.md
+++ b/.changeset/long-cups-bow.md
@@ -1,0 +1,5 @@
+---
+"@guardian/react-crossword": patch
+---
+
+Display multiline instructions on multiple lines

--- a/.changeset/tricky-ravens-learn.md
+++ b/.changeset/tricky-ravens-learn.md
@@ -1,0 +1,5 @@
+---
+"@guardian/react-crossword": patch
+---
+
+Support formatted instructions

--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -791,7 +791,7 @@ class Crossword extends Component {
             <header className="instructions__title">
               Special instructions
             </header>
-            {this.instructions}
+            <span dangerouslySetInnerHTML={{ __html: this.instructions }} />
           </div>
         )}
         <Clues

--- a/src/stylesheets/crosswords/_clues.scss
+++ b/src/stylesheets/crosswords/_clues.scss
@@ -3,6 +3,7 @@
     @include fs-textSans(5);
     width: 100%;
     clear: both;
+    white-space: pre-line;
 
     .instructions__title { 
         font-weight: bold;

--- a/src/stylesheets/crosswords/_vars.scss
+++ b/src/stylesheets/crosswords/_vars.scss
@@ -19,5 +19,6 @@ $xword-grid-sizes: (
     genius: 15,
     speedy: 13,
     everyman: 15,
-    weekend: 13
+    weekend: 13,
+    quick-cryptic: 11
 );

--- a/src/stylesheets/print.scss
+++ b/src/stylesheets/print.scss
@@ -132,4 +132,5 @@
 .crossword__instructions {
     font-size: 13px;
     text-align: left;
+    white-space: pre-line;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

follows #27 

## What does this change?

Adds support for [Quick cryptic crosswords](https://www.theguardian.com/crosswords/series/quick-cryptic) with 3 changes

- Define the expected width for quick-cryptic crosswords (11 cells)
- Set the CSS to show multiline crosswords on multiple lines
- Render instructions as HTML to support formatting (eg. `<b>, <i>, <sub>` tags etc. not yet used on quick cryptics but coming soon)

