### PR TITLE
Apply formatting tags in sticky clues

### DIFF
--- a/.changeset/two-lizards-search.md
+++ b/.changeset/two-lizards-search.md
@@ -1,0 +1,5 @@
+---
+"@guardian/react-crossword": patch
+---
+
+Apply formatting tags in sticky clues

--- a/examples/exampleCrossword.js
+++ b/examples/exampleCrossword.js
@@ -17,7 +17,7 @@ root.render(
           id: '1-across',
           number: 1,
           humanNumber: '1',
-          clue: 'Toy on a string (2-2)',
+          clue: '<i>Toy</i> on a string (2-2)',
           direction: 'across',
           length: 4,
           group: ['1-across'],

--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -758,7 +758,7 @@ class Crossword extends Component {
                       </span>
                     </strong>
                     {' '}
-                    {focused.clue}
+                    <span dangerouslySetInnerHTML={{ __html: focused.clue }} />
                   </div>
                 </div>
               )}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We sometimes send clues with some light, restricted formatting - usually `<b>` or `<i>` tags. These get rendered in the main clues list https://github.com/guardian/react-crossword/blob/8b1088a7c72245cacc0ae05b991526b18b97a368/src/javascripts/crosswords/clues.js#L33-L36 (and instructions) but we don't yet do the same for the sticky clue that appears above the player when we have a clue selected. This alters that to do the same rendering as the main clues list.

## How to test

Open the updated example crossword in this PR, reduce your screen to a narrow breakpoint and select the 1-across clue. Is the sticky clue now italicising the text?


## Images

Before | After
-------|--------
<img width="480" alt="image" src="https://github.com/guardian/react-crossword/assets/10963046/f2515a3b-65c6-4ff7-9c13-a724ad82b978"> | <img width="477" alt="image" src="https://github.com/guardian/react-crossword/assets/10963046/806b4b90-0c5b-496b-8138-c480de059be8">

