### PR TITLE
Remove bean and update fastdom usage

### DIFF
--- a/.changeset/cuddly-spies-shave.md
+++ b/.changeset/cuddly-spies-shave.md
@@ -1,0 +1,5 @@
+---
+"@guardian/react-crossword": patch
+---
+
+Remove bean and update fastdom usages

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "author": "The Guardian, Chris Zetter",
   "private": false,
   "dependencies": {
-    "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "fastdom": "1.0.12",
     "lodash": "^4.17.21",

--- a/src/javascripts/crosswords/clues.js
+++ b/src/javascripts/crosswords/clues.js
@@ -1,6 +1,5 @@
 // eslint-disable-next-line max-classes-per-file
 import React, { Component, createRef } from 'react';
-import bean from 'bean';
 import fastdom from 'fastdom';
 import { classNames } from './classNames';
 import { isBreakpoint } from '../lib/detect';
@@ -54,8 +53,8 @@ class Clues extends Component {
 
     const height = this.$cluesNode.scrollHeight - this.$cluesNode.clientHeight;
 
-    bean.on(this.$cluesNode, 'scroll', (e) => {
-      const showGradient = height - e.currentTarget.scrollTop > 25;
+    this.$cluesNode.addEventListener('scroll', (event) => {
+      const showGradient = height - event.currentTarget.scrollTop > 25;
 
       if (this.state.showGradient !== showGradient) {
         this.setState({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,11 +3015,6 @@ base-x@^3.0.8:
   dependencies:
     safe-buffer "^5.0.1"
 
-bean@~1.0.14:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/bean/-/bean-1.0.15.tgz#b4a9fff82618b071471676c8b190868048c34775"
-  integrity sha512-/X7mF8caOC3qZYSJu62wEJ7AO5/ZIKwwvjBFded5s8IDdRLJSAXfYLJaNPIa/ALThJIWtqtJbbfGbGOjISX1bw==
-
 better-path-resolve@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/better-path-resolve/-/better-path-resolve-1.0.0.tgz#13a35a1104cdd48a7b74bf8758f96a1ee613f99d"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The fastdom API has changed in one of the updated versions; "read" is now "measure" and "write" is "mutate". I'd link to a migration doc or changelog but I couldn't find any, the closest I could find was this PR comment https://github.com/wilsonpage/fastdom/pull/58#issuecomment-94566836. Without this change, the example page wouldn't open on a narrow breakpoint

Also removes the bean dependency; it doesn't conform to strict mode JS requirements, which was a pain to work around. I can't see that it's providing any functionality not already provided by `.addEventListener` - so I removed it entirely 

## How to test

Run the example - does the player behave as before - especially around opening on a narrow breakpoint, and/or the fade at the bottom of the clue list when scrolling through it

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
