### PR TITLE
chore: Fastdom Fixes

### DIFF
--- a/.changeset/wicked-oranges-march.md
+++ b/.changeset/wicked-oranges-march.md
@@ -1,0 +1,5 @@
+---
+"@guardian/react-crossword": major
+---
+
+Makes Fastdom work again and makes a styling change that may break non Edition styling

--- a/docs/crosswords-history.md
+++ b/docs/crosswords-history.md
@@ -1,0 +1,46 @@
+# React Crossword Docs - Editions
+
+## History of the Repo
+
+The codebase was originally created by a Guardian user. It's made up of plain javascript, React and SASS. After discussion with the user, the repository was forked and kept under the Guardian github organisation. It was then published to npm under the namespace `@guardian/react-crossword`.
+
+This bundle is then being used in the Editions app to power the crosswords for the Daily Edition.
+
+## Bundling
+
+Previously, this repo used to bundle using Webpack 4. However, due to a large amount of vulnerabilities, and the reality was, the bundling that needed to happen was a very simple javascript module, it was then moved across to Parcel. Parcel offered what we needed - simple serving and bundling.
+
+## How it integrates with Editions
+
+### `Apps/crosswords`
+
+The editions repo is a monorepo. Within than monorepo, is a yarn workspace (yes another monorepo) called `Apps` . One of the packages is called `crosswords`. This package is a simple React app that consumes the `@guardian/react-crossword` package as its top level component. Crossword data is loaded into the `window` object which is passed into this component which allows it to display.
+
+The following package scripts are important:
+
+- `watch` - which will serve the app mentioned above. This is run using parcel. This was previously run using Webpack.
+- `build` - Which creates a local bundle into the `dist` folder. This was previously built using webpack.
+- `html-update` - This calls a script in the `scripts` folder that takes the bundled `index.html` file and modifies it so that it can be run under the `file` protocol instead of the `http` protocol. Basically, running the app in a browser by opening the `index.html` file, and without serving it.
+
+There is a script in the `scripts` folder called `bundle-html` which acts as the main point for bundling this app. It runs `yarn build` and then kicks off the `html-update`. We then move this code into the `Mallard` (react native app) after we have removed the previous bundle. We talk about this bundle next
+
+### `html/crosswords.bundle`
+
+This folder exists at the top level of `Mallard`. It contains the bundle files from `Apps/crosswords` that have been modified by the `html-update` script. This `crosswords.bundle` folder is imported into the iOS and Android projects and is built as part of it.
+
+When running the app in dev mode, the watch script in `Apps/crossword` is run, creating a served version of the crossword which is then run in the webview. When the app is built for production, it uses these local files.
+
+The crossword is served from this file in `Mallard` `src/components/article/types/crossword.tsx`. For development purposes, you can switch between prod and dev in the `getBundleUri` function called by this component. Please note, if you perform any builds, the apps need to be re-run again to contain the new crossword bundle.
+
+## Recent issues
+
+Not being able to publish `@guardian/react-crossword` to npm. This has now been resolved.
+
+The latest version uses a Parcel bundle which currently doesn’t work in the setup above, within the App, where the previous Webpack 4 version did. It does run and bundle correctly within its own package.
+
+I have also managed to get it to run correctly in `Apps/crossword` serving it locally, but not within the app.
+
+## Next Steps
+
+1. Update `Apps/crosswords` to use the `homepage` package JSON property to force the file protocol when bundling. This will remove the need for the `html-update` script. This should be tried with the `0.2.3` version of `@guardian/react-crossword` as we know that to work. This should simplify the process a little
+2. Either update the bundling in `@guardian/react-crossword` or `Apps/crosswords` or both - to fix the issues of it running in the app.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
-    "fastdom": "1.0.11",
+    "fastdom": "1.0.12",
     "lodash": "^4.17.21",
     "qwery": "4.0.0",
     "react": "18.2.0",
@@ -70,7 +70,7 @@
   "files": [
     "lib"
   ],
-  "main": "lib/index.js",
+  "module": "lib/index.js",
   "source": "src/javascripts/crosswords/crossword.js",
   "description": "Guardian React Crossword"
 }

--- a/src/javascripts/crosswords/anagram-helper/main.js
+++ b/src/javascripts/crosswords/anagram-helper/main.js
@@ -1,17 +1,17 @@
-import React, { Component } from 'react';
-import shuffle from 'lodash/shuffle';
-import closeCentralIcon from 'bundle-text:../../../svgs/close.svg';
-import { cellsForClue, getAnagramClueData } from '../helpers';
-import { ClueInput } from './clue-input';
-import { CluePreview } from './clue-preview';
-import { Ring } from './ring';
+import React, { Component } from "react";
+import shuffle from "lodash/shuffle";
+import closeCentralIcon from "bundle-text:../../../svgs/close.svg";
+import { cellsForClue, getAnagramClueData } from "../helpers";
+import { ClueInput } from "./clue-input";
+import { CluePreview } from "./clue-preview";
+import { Ring } from "./ring";
 
 class AnagramHelper extends Component {
   constructor() {
     super();
     this.state = {
       letters: [],
-      clueInput: '',
+      clueInput: "",
       showInput: true,
     };
   }
@@ -44,7 +44,7 @@ class AnagramHelper extends Component {
     return shuffle(
       word
         .trim()
-        .split('')
+        .split("")
         .sort()
         .reduce(
           (acc, letter) => {
@@ -62,8 +62,8 @@ class AnagramHelper extends Component {
           {
             letters: [],
             entries: wordEntries,
-          },
-        ).letters,
+          }
+        ).letters
     );
   }
 
@@ -79,7 +79,7 @@ class AnagramHelper extends Component {
   reset() {
     if (this.state.clueInput) {
       this.setState({
-        clueInput: '',
+        clueInput: "",
         showInput: true,
       });
     }
@@ -103,7 +103,7 @@ class AnagramHelper extends Component {
     };
     const clue = getAnagramClueData(
       this.props.entries,
-      this.props.focussedEntry,
+      this.props.focussedEntry
     );
 
     const inner = this.state.showInput ? (
@@ -132,7 +132,7 @@ class AnagramHelper extends Component {
         />
         <button
           className={`button button--large ${
-            !this.state.clueInput ? 'button--tertiary' : ''
+            !this.state.clueInput ? "button--tertiary" : ""
           }`}
           onClick={this.reset.bind(this)}
           data-link-name="Start Again"
@@ -141,7 +141,7 @@ class AnagramHelper extends Component {
         </button>
         <button
           className={`button button--large ${
-            this.canShuffle() ? '' : 'button--tertiary'
+            this.canShuffle() ? "" : "button--tertiary"
           }`}
           onClick={this.shuffle.bind(this)}
           data-link-name="Shuffle"

--- a/src/javascripts/crosswords/clues.js
+++ b/src/javascripts/crosswords/clues.js
@@ -1,10 +1,10 @@
 // eslint-disable-next-line max-classes-per-file
-import React, { Component, createRef } from 'react';
-import bean from 'bean';
-import fastdom from 'fastdom';
-import { classNames } from './classNames';
-import { isBreakpoint } from '../lib/detect';
-import { scrollTo } from '../lib/scroller';
+import React, { Component, createRef } from "react";
+import bean from "bean";
+import fastdom from "fastdom";
+import { classNames } from "./classNames";
+import { isBreakpoint } from "../lib/detect";
+import { scrollTo } from "../lib/scroller";
 
 class Clue extends Component {
   onClick(e) {
@@ -21,9 +21,9 @@ class Clue extends Component {
           onClick={this.onClick.bind(this)}
           className={classNames({
             crossword__clue: true,
-            'crossword__clue--answered': this.props.hasAnswered,
-            'crossword__clue--selected': this.props.isSelected,
-            'crossword__clue--display-group-order':
+            "crossword__clue--answered": this.props.hasAnswered,
+            "crossword__clue--selected": this.props.isSelected,
+            "crossword__clue--display-group-order":
               JSON.stringify(this.props.number) !== this.props.humanNumber,
           })}
         >
@@ -54,7 +54,7 @@ class Clues extends Component {
 
     const height = this.$cluesNode.scrollHeight - this.$cluesNode.clientHeight;
 
-    bean.on(this.$cluesNode, 'scroll', (e) => {
+    bean.on(this.$cluesNode, "scroll", (e) => {
       const showGradient = height - e.currentTarget.scrollTop > 25;
 
       if (this.state.showGradient !== showGradient) {
@@ -71,13 +71,13 @@ class Clues extends Component {
   componentDidUpdate(prev) {
     if (
       isBreakpoint({
-        min: 'tablet',
-        max: 'leftCol',
-      })
-      && this.props.focussed
-      && (!prev.focussed || prev.focussed.id !== this.props.focussed.id)
+        min: "tablet",
+        max: "leftCol",
+      }) &&
+      this.props.focussed &&
+      (!prev.focussed || prev.focussed.id !== this.props.focussed.id)
     ) {
-      fastdom.read(() => {
+      fastdom.measure(() => {
         this.scrollIntoView(this.props.focussed);
       });
     }
@@ -85,60 +85,59 @@ class Clues extends Component {
 
   scrollIntoView(clue) {
     const buffer = 100;
-    const node = this.cluesRef.current[clue.id];
-    const visible = node.offsetTop - buffer > this.$cluesNode.scrollTop
-      && node.offsetTop + buffer
-        < this.$cluesNode.scrollTop + this.$cluesNode.clientHeight;
+    const node = this.cluesRef.current.querySelector(`[href="#${clue.id}"]`);
+    const visible =
+      node.offsetTop - buffer > this.$cluesNode.scrollTop &&
+      node.offsetTop + buffer <
+        this.$cluesNode.scrollTop + this.$cluesNode.clientHeight;
 
     if (!visible) {
       const offset = node.offsetTop - this.$cluesNode.clientHeight / 2;
-      scrollTo(offset, 250, 'easeOutQuad', this.$cluesNode);
+      scrollTo(offset, 250, "easeOutQuad", this.$cluesNode);
     }
   }
 
   render() {
-    const headerClass = 'crossword__clues-header';
-    const cluesByDirection = (direction) => this.props.clues
-      .filter((clue) => clue.entry.direction === direction)
-      .map((clue) => (
-        <Clue
-          ref={(clueRef) => {
-            this[clue.entry.id] = clueRef;
-          }}
-          id={clue.entry.id}
-          key={clue.entry.id}
-          number={clue.entry.number}
-          humanNumber={clue.entry.humanNumber}
-          clue={clue.entry.clue}
-          hasAnswered={clue.hasAnswered}
-          isSelected={clue.isSelected}
-          focusFirstCellInClueById={this.props.focusFirstCellInClueById}
-          setReturnPosition={() => {
-            this.props.setReturnPosition(window.scrollY);
-          }}
-        />
-      ));
+    const headerClass = "crossword__clues-header";
+    const cluesByDirection = (direction) =>
+      this.props.clues
+        .filter((clue) => clue.entry.direction === direction)
+        .map((clue) => (
+          <Clue
+            ref={(clueRef) => {
+              this[clue.entry.id] = clueRef;
+            }}
+            id={clue.entry.id}
+            key={clue.entry.id}
+            number={clue.entry.number}
+            humanNumber={clue.entry.humanNumber}
+            clue={clue.entry.clue}
+            hasAnswered={clue.hasAnswered}
+            isSelected={clue.isSelected}
+            focusFirstCellInClueById={this.props.focusFirstCellInClueById}
+            setReturnPosition={() => {
+              this.props.setReturnPosition(window.scrollY);
+            }}
+          />
+        ));
 
     return (
       <div
         className={`crossword__clues--wrapper ${
-          this.state.showGradient ? '' : 'hide-gradient'
+          this.state.showGradient ? "" : "hide-gradient"
         }`}
       >
-        <div
-          className="crossword__clues"
-          ref={this.cluesRef}
-        >
+        <div className="crossword__clues" ref={this.cluesRef}>
           <div className="crossword__clues--across">
             <h3 className={headerClass}>Across</h3>
             <ol className="crossword__clues-list">
-              {cluesByDirection('across')}
+              {cluesByDirection("across")}
             </ol>
           </div>
           <div className="crossword__clues--down">
             <h3 className={headerClass}>Down</h3>
             <ol className="crossword__clues-list">
-              {cluesByDirection('down')}
+              {cluesByDirection("down")}
             </ol>
           </div>
         </div>

--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -1,19 +1,19 @@
-import '../../stylesheets/main.scss';
-import React, { Component } from 'react';
-import { findDOMNode } from 'react-dom';
-import fastdom from 'fastdom';
-import debounce from 'lodash/debounce';
-import zip from 'lodash/zip';
-import $ from '../lib/$';
-import mediator from '../lib/mediator';
-import { isBreakpoint } from '../lib/detect';
-import { scrollTo } from '../lib/scroller';
-import { addEventListener } from '../lib/events';
-import { AnagramHelper } from './anagram-helper/main';
-import { Clues } from './clues';
-import { Controls } from './controls';
-import { HiddenInput } from './hidden-input';
-import { Grid } from './grid';
+import "../../stylesheets/main.scss";
+import React, { Component } from "react";
+import { findDOMNode } from "react-dom";
+import fastdom from "fastdom";
+import debounce from "lodash/debounce";
+import zip from "lodash/zip";
+import $ from "../lib/$";
+import mediator from "../lib/mediator";
+import { isBreakpoint } from "../lib/detect";
+import { scrollTo } from "../lib/scroller";
+import { addEventListener } from "../lib/events";
+import { AnagramHelper } from "./anagram-helper/main";
+import { Clues } from "./clues";
+import { Controls } from "./controls";
+import { HiddenInput } from "./hidden-input";
+import { Grid } from "./grid";
 import {
   buildClueMap,
   buildGrid,
@@ -31,10 +31,10 @@ import {
   checkClueHasBeenAnswered,
   buildSeparatorMap,
   cellsForEntry,
-} from './helpers';
-import { keycodes } from './keycodes';
-import { saveGridState, loadGridState } from './persistence';
-import { classNames } from './classNames';
+} from "./helpers";
+import { keycodes } from "./keycodes";
+import { saveGridState, loadGridState } from "./persistence";
+import { classNames } from "./classNames";
 
 class Crossword extends Component {
   constructor(props) {
@@ -51,7 +51,7 @@ class Crossword extends Component {
         dimensions.rows,
         dimensions.cols,
         this.props.data.entries,
-        this.props.loadGrid(this.props.id),
+        this.props.loadGrid(this.props.id)
       ),
       cellInFocus: null,
       directionOfEntry: null,
@@ -64,14 +64,14 @@ class Crossword extends Component {
     const $stickyClueWrapper = $(findDOMNode(this.stickyClueWrapper));
     const $game = $(findDOMNode(this.game));
 
-    mediator.on('window:resize', debounce(this.setGridHeight.bind(this), 200));
+    mediator.on("window:resize", debounce(this.setGridHeight.bind(this), 200));
     mediator.on(
-      'window:orientationchange',
-      debounce(this.setGridHeight.bind(this), 200),
+      "window:orientationchange",
+      debounce(this.setGridHeight.bind(this), 200)
     );
     this.setGridHeight();
 
-    addEventListener(window, 'scroll', () => {
+    addEventListener(window, "scroll", () => {
       const gameOffset = $game.offset();
       const stickyClueWrapperOffset = $stickyClueWrapper.offset();
       const scrollY = window.scrollY;
@@ -82,27 +82,27 @@ class Crossword extends Component {
         const gameOffsetBottom = gameOffset.top + gameOffset.height;
 
         if (scrollY > gameOffsetBottom - stickyClueWrapperOffset.height) {
-          $stickyClueWrapper.css({ top: 'auto', bottom: 0 });
+          $stickyClueWrapper.css({ top: "auto", bottom: 0 });
         } else {
           $stickyClueWrapper.css({
             top: scrollYPastGame,
-            bottom: '',
+            bottom: "",
           });
         }
       } else {
-        $stickyClueWrapper.css({ top: '', bottom: '' });
+        $stickyClueWrapper.css({ top: "", bottom: "" });
       }
     });
 
-    const entryId = window.location.hash.replace('#', '');
+    const entryId = window.location.hash.replace("#", "");
     this.focusFirstCellInClueById(entryId);
   }
 
   componentDidUpdate(prevProps, prevState) {
     // return focus to active cell after exiting anagram helper
     if (
-      !this.state.showAnagramHelper
-      && this.state.showAnagramHelper !== prevState.showAnagramHelper
+      !this.state.showAnagramHelper &&
+      this.state.showAnagramHelper !== prevState.showAnagramHelper
     ) {
       this.focusCurrentCell();
     }
@@ -113,15 +113,15 @@ class Crossword extends Component {
 
     if (!event.metaKey && !event.ctrlKey && !event.altKey) {
       if (
-        event.keyCode === keycodes.backspace
-        || event.keyCode === keycodes.delete
+        event.keyCode === keycodes.backspace ||
+        event.keyCode === keycodes.delete
       ) {
         event.preventDefault();
         if (cell) {
           if (this.cellIsEmpty(cell.x, cell.y)) {
             this.focusPrevious();
           } else {
-            this.setCellValue(cell.x, cell.y, '');
+            this.setCellValue(cell.x, cell.y, "");
             this.saveGrid();
           }
         }
@@ -148,13 +148,14 @@ class Crossword extends Component {
     const focussedClue = this.clueInFocus();
     let newDirection;
 
-    const isInsideFocussedClue = () => (focussedClue ? entryHasCell(focussedClue, x, y) : false);
+    const isInsideFocussedClue = () =>
+      focussedClue ? entryHasCell(focussedClue, x, y) : false;
 
     if (
-      cellInFocus
-      && cellInFocus.x === x
-      && cellInFocus.y === y
-      && this.state.directionOfEntry
+      cellInFocus &&
+      cellInFocus.x === x &&
+      cellInFocus.y === y &&
+      this.state.directionOfEntry
     ) {
       /** User has clicked again on the highlighted cell, meaning we ought to swap direction */
       newDirection = otherDirection(this.state.directionOfEntry);
@@ -175,21 +176,22 @@ class Crossword extends Component {
         y,
       };
 
-      const isStartOfClue = (sourceClue) => !!sourceClue
-        && sourceClue.position.x === x
-        && sourceClue.position.y === y;
+      const isStartOfClue = (sourceClue) =>
+        !!sourceClue &&
+        sourceClue.position.x === x &&
+        sourceClue.position.y === y;
 
       /**
        * If the user clicks on the start of a down clue midway through an across clue, we should
        * prefer to highlight the down clue.
        */
       if (!isStartOfClue(clue.across) && isStartOfClue(clue.down)) {
-        newDirection = 'down';
+        newDirection = "down";
       } else if (clue.across) {
         /** Across is the default focus otherwise */
-        newDirection = 'across';
+        newDirection = "across";
       } else {
-        newDirection = 'down';
+        newDirection = "down";
       }
       this.focusClue(x, y, newDirection);
     }
@@ -220,11 +222,11 @@ class Crossword extends Component {
     this.setState({
       grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
         const previousValue = cell.value;
-        cell.value = '';
+        cell.value = "";
         this.props.onMove({
           x: gridX,
           y: gridY,
-          value: '',
+          value: "",
           previousValue,
         });
         return cell;
@@ -244,18 +246,18 @@ class Crossword extends Component {
         this.state.grid,
         this.clueMap,
         this.props.data.entries,
-        clueInFocus,
+        clueInFocus
       );
 
       this.setState({
         grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
           if (cellsInFocus.some((c) => c.x === gridX && c.y === gridY)) {
             const previousValue = cell.value;
-            cell.value = '';
+            cell.value = "";
             this.props.onMove({
               x: gridX,
               y: gridY,
-              value: '',
+              value: "",
               previousValue,
             });
           }
@@ -292,7 +294,7 @@ class Crossword extends Component {
     /* We need to handle touch seperately as touching an input on iPhone does not fire the
          click event - listen for a touchStart and preventDefault to avoid calling onSelect twice on
          devices that fire click AND touch events. The click event doesn't fire only when the input is already focused */
-    if (event.type === 'touchstart') {
+    if (event.type === "touchstart") {
       event.preventDefault();
     }
   }
@@ -304,23 +306,23 @@ class Crossword extends Component {
 
     if (
       isBreakpoint({
-        max: 'tablet',
+        max: "tablet",
       })
     ) {
-      fastdom.read(() => {
+      fastdom.measure(() => {
         // Our grid is a square, set the height of the grid wrapper
         // to the width of the grid wrapper
-        fastdom.write(() => {
+        fastdom.mutate(() => {
           this.$gridWrapper.css(
-            'height',
-            `${this.$gridWrapper.offset().width}px`,
+            "height",
+            `${this.$gridWrapper.offset().width}px`
           );
         });
         this.gridHeightIsSet = true;
       });
     } else if (this.gridHeightIsSet) {
       // Remove inline style if tablet and wider
-      this.$gridWrapper.attr('style', '');
+      this.$gridWrapper.attr("style", "");
     }
   }
 
@@ -360,7 +362,7 @@ class Crossword extends Component {
         this.rows,
         this.columns,
         this.props.data.entries,
-        gridState,
+        gridState
       ),
     });
   }
@@ -369,9 +371,9 @@ class Crossword extends Component {
     const characterUppercase = character.toUpperCase();
     const cell = this.state.cellInFocus;
     if (
-      /[A-Za-zÀ-ÿ0-9]/.test(characterUppercase)
-      && characterUppercase.length === 1
-      && cell
+      /[A-Za-zÀ-ÿ0-9]/.test(characterUppercase) &&
+      characterUppercase.length === 1 &&
+      cell
     ) {
       this.setCellValue(cell.x, cell.y, characterUppercase);
       this.saveGrid();
@@ -386,11 +388,11 @@ class Crossword extends Component {
   goToReturnPosition() {
     if (
       isBreakpoint({
-        max: 'mobile',
+        max: "mobile",
       })
     ) {
       if (this.returnPosition) {
-        scrollTo(this.returnPosition, 250, 'easeOutQuad');
+        scrollTo(this.returnPosition, 250, "easeOutQuad");
       }
       this.returnPosition = null;
     }
@@ -429,24 +431,24 @@ class Crossword extends Component {
 
     const x = cell.x + deltaX;
     const y = cell.y + deltaY;
-    let direction = 'down';
+    let direction = "down";
 
     if (
-      this.state.grid[x]
-      && this.state.grid[x][y]
-      && this.state.grid[x][y].isEditable
+      this.state.grid[x] &&
+      this.state.grid[x][y] &&
+      this.state.grid[x][y].isEditable
     ) {
       if (deltaY !== 0) {
-        direction = 'down';
+        direction = "down";
       } else if (deltaX !== 0) {
-        direction = 'across';
+        direction = "across";
       }
       this.focusClue(x, y, direction);
     }
   }
 
   isAcross() {
-    return this.state.directionOfEntry === 'across';
+    return this.state.directionOfEntry === "across";
   }
 
   focusPrevious() {
@@ -479,7 +481,7 @@ class Crossword extends Component {
           this.focusClue(
             newClue.position.x,
             newClue.position.y,
-            newClue.direction,
+            newClue.direction
           );
         }
       } else if (this.isAcross()) {
@@ -562,7 +564,7 @@ class Crossword extends Component {
       const cluesForCell = cluesFor(
         this.clueMap,
         this.state.cellInFocus.x,
-        this.state.cellInFocus.y,
+        this.state.cellInFocus.y
       );
 
       if (this.state.directionOfEntry) {
@@ -573,7 +575,9 @@ class Crossword extends Component {
   }
 
   allHighlightedClues() {
-    return this.props.data.entries.filter((clue) => this.clueIsInFocusGroup(clue));
+    return this.props.data.entries.filter((clue) =>
+      this.clueIsInFocusGroup(clue)
+    );
   }
 
   clueIsInFocusGroup(clue) {
@@ -581,15 +585,15 @@ class Crossword extends Component {
       const cluesForCell = cluesFor(
         this.clueMap,
         this.state.cellInFocus.x,
-        this.state.cellInFocus.y,
+        this.state.cellInFocus.y
       );
 
       if (
-        this.state.directionOfEntry
-        && cluesForCell[this.state.directionOfEntry]
+        this.state.directionOfEntry &&
+        cluesForCell[this.state.directionOfEntry]
       ) {
         return cluesForCell[this.state.directionOfEntry].group.includes(
-          clue.id,
+          clue.id
         );
       }
     }
@@ -614,9 +618,10 @@ class Crossword extends Component {
       this.setState({
         grid: mapGrid(this.state.grid, (cell, x, y) => {
           if (cells.some((c) => c.x === x && c.y === y)) {
-            const n = entry.direction === 'across'
-              ? x - entry.position.x
-              : y - entry.position.y;
+            const n =
+              entry.direction === "across"
+                ? x - entry.position.x
+                : y - entry.position.y;
             const previousValue = cell.value;
             cell.value = entry.solution[n];
             this.props.onMove({
@@ -637,7 +642,7 @@ class Crossword extends Component {
     const cells = cellsForEntry(entry);
 
     if (entry.solution) {
-      const badCells = zip(cells, entry.solution.split(''))
+      const badCells = zip(cells, entry.solution.split(""))
         .filter((cellAndSolution) => {
           const coords = cellAndSolution[0];
           const cell = this.state.grid[coords.x][coords.y];
@@ -650,11 +655,11 @@ class Crossword extends Component {
         grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
           if (badCells.some((bad) => bad.x === gridX && bad.y === gridY)) {
             const previousValue = cell.value;
-            cell.value = '';
+            cell.value = "";
             this.props.onMove({
               x: gridX,
               y: gridY,
-              value: '',
+              value: "",
               previousValue,
             });
           }
@@ -674,20 +679,20 @@ class Crossword extends Component {
       currentValue = this.state.grid[cell.x][cell.y].value;
     }
 
-    return currentValue || '';
+    return currentValue || "";
   }
 
   hasSolutions() {
-    return 'solution' in this.props.data.entries[0];
+    return "solution" in this.props.data.entries[0];
   }
 
   isHighlighted(x, y) {
     const focused = this.clueInFocus();
     return focused
       ? focused.group.some((id) => {
-        const entry = this.props.data.entries.find((e) => e.id === id);
-        return entryHasCell(entry, x, y);
-      })
+          const entry = this.props.data.entries.find((e) => e.id === id);
+          return entryHasCell(entry, x, y);
+        })
       : false;
   }
 
@@ -743,21 +748,19 @@ class Crossword extends Component {
           >
             <div
               className={classNames({
-                'crossword__sticky-clue': true,
-                'is-hidden': !focused,
+                "crossword__sticky-clue": true,
+                "is-hidden": !focused,
               })}
             >
               {focused && (
                 <div className="crossword__sticky-clue__inner">
                   <div className="crossword__sticky-clue__inner__inner">
                     <strong>
-                      {focused.number}
-                      {' '}
+                      {focused.number}{" "}
                       <span className="crossword__sticky-clue__direction">
                         {focused.direction}
                       </span>
-                    </strong>
-                    {' '}
+                    </strong>{" "}
                     {focused.clue}
                   </div>
                 </div>

--- a/src/javascripts/lib/scroller.js
+++ b/src/javascripts/lib/scroller.js
@@ -8,28 +8,28 @@
     Note: if you pass in an element, you must also specify an easing function.
 */
 
-import bonzo from 'bonzo';
-import fastdom from 'fastdom';
-import { createEasing } from './easing';
+import bonzo from "bonzo";
+import fastdom from "fastdom";
+import { createEasing } from "./easing";
 
 const scrollTo = (
   offset,
   duration = 0,
-  easeFn = 'easeOutQuad',
-  container = document.body,
+  easeFn = "easeOutQuad",
+  container = document.body
 ) => {
   const $container = bonzo(container);
   const from = $container.scrollTop();
   const distance = offset - from;
   const ease = createEasing(easeFn, duration);
   const scrollFn = () => {
-    fastdom.write(() => $container.scrollTop(from + ease() * distance));
+    fastdom.mutate(() => $container.scrollTop(from + ease() * distance));
   };
   const interval = setInterval(scrollFn, 15);
 
   setTimeout(() => {
     clearInterval(interval);
-    fastdom.write(() => $container.scrollTop(offset));
+    fastdom.mutate(() => $container.scrollTop(offset));
   }, duration);
 };
 

--- a/src/stylesheets/crosswords/_anagram-helper.scss
+++ b/src/stylesheets/crosswords/_anagram-helper.scss
@@ -8,6 +8,7 @@
     padding-top: 2.5%;
     background: $brightness-97;
     text-align: center;
+    z-index: 1;
 
     .button:last-of-type {
         margin-right: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4351,10 +4351,10 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fastdom@1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fastdom/-/fastdom-1.0.11.tgz#f22984f9df6b9a6081e5ce2e49cfb5525daf198a"
-  integrity sha512-jl9MwXDFxhg354W4E3s1UMsLh3HWFuVMQiRUlXpHckcHRXQvUe76yzBf1Z7b+x5Ci4TUJ1KmynI9alGUXG95IQ==
+fastdom@1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fastdom/-/fastdom-1.0.12.tgz#ae43d55af017252ae499b2e186511ab97412de39"
+  integrity sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==
   dependencies:
     strictdom "^1.0.1"
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When running the crossword through the new build process in Editions, we were seeing `fastdom` errors. This was because the methods being called were no longer available. This was causing the crossword to crash.

## How to test

Difficult to test this at the moment due to the next piece being the updates to Editions, however, running locally should still work as expected

## Outputs

Tested on iOS and Android simulators and all appear to be working.

![Simulator Screenshot - iPhone 13 Pro - 2024-06-24 at 09 07 47](https://github.com/guardian/react-crossword/assets/935975/84f67aec-9fa1-468d-9c39-01547e9f0b0b)

