### PR TITLE
resize the crossword grid by dimensions, not the type

### DIFF
--- a/.changeset/gentle-lies-change.md
+++ b/.changeset/gentle-lies-change.md
@@ -1,0 +1,13 @@
+---
+"@guardian/react-crossword": minor
+---
+
+Resize the crossword grid by dimensions, not the type.
+
+Previously the crossword grid would look up the crossword type in a table to
+know how many cells were in the grid, so how wide to make the input box. This
+meant that eg. quick crosswords must always be 13x13 grids, prizes 15x15 etc.
+But this is unnecessarily limiting on setters, there's no reason we couldn't
+have a small 11x11 cryptic, or a jumbo 21x21 quick. Create CSS classes to
+control the grid size, and create one for each odd cell width from 11 up to 27,
+and read the dimension from the crossword data.

--- a/src/javascripts/crosswords/crossword.js
+++ b/src/javascripts/crosswords/crossword.js
@@ -725,8 +725,8 @@ class Crossword extends Component {
     return (
       <div
         className={`crossword__container crossword__container--${
-          this.props.data.crosswordType || this.props.data.type
-        } crossword__container--react`}
+          this.props.data.dimensions.cols
+        }cell crossword__container--react`}
         data-link-name="Crosswords"
       >
         <div

--- a/src/stylesheets/crosswords/_cell.scss
+++ b/src/stylesheets/crosswords/_cell.scss
@@ -32,20 +32,6 @@
     opacity: 1;
     -webkit-font-smoothing: subpixel-antialiased;
     transition: opacity .15s ease-in;
-
-    @each $xword, $cells in $xword-grid-sizes {
-        .crossword__container--#{$xword} & {
-            font-size: ceil(1.2px * $cells);
-
-            @include mq(tablet) {
-                font-size: 1.1px * $cells;
-            }
-
-            @include mq($from:desktop, $and:'(orientation: portrait)') {  
-                font-size: ceil(1.2px * $cells);
-            }
-        }
-    }
 }
 
 .crossword__cell-text--focussed {

--- a/src/stylesheets/crosswords/_layout.scss
+++ b/src/stylesheets/crosswords/_layout.scss
@@ -2,10 +2,11 @@
     @return $cells * ($xword-cell-width + $xword-border-width) + $xword-border-width;
 }
 
-@each $xword, $cells in $xword-grid-sizes {
-    $size: xword-grid-dimensions($cells);
+@each $cells in $xword-cell-sizes {
+    $max-size: 481px; // width of 15-cell grid
+    $size: min($max-size, xword-grid-dimensions($cells));
 
-    .crossword__container--#{$xword} {
+    .crossword__container--#{$cells}cell {
         @include mq(tablet) {
             padding-left: $size;
 

--- a/src/stylesheets/crosswords/_vars.scss
+++ b/src/stylesheets/crosswords/_vars.scss
@@ -11,14 +11,4 @@ $xword-focussed-background-colour: #fff7b2;
 
 $xword-clue-number-width: 32px;
 
-$xword-grid-sizes: (
-    quick: 13,
-    cryptic: 15,
-    prize: 15,
-    quiptic: 15,
-    genius: 15,
-    speedy: 13,
-    everyman: 15,
-    weekend: 13,
-    quick-cryptic: 11
-);
+$xword-cell-sizes: 11, 13, 15, 17, 19, 21, 23, 25, 27;


### PR DESCRIPTION
Resize the crossword grid by dimensions, not the type.

Previously the crossword grid would look up the crossword type in a table to
know how many cells were in the grid, so how wide to make the input box. This
meant that eg. quick crosswords must always be 13x13 grids, prizes 15x15 etc.
But this is unnecessarily limiting on setters, there's no reason we couldn't
have a small 11x11 cryptic, or a jumbo 21x21 quick. Create CSS classes to
control the grid size, and create one for each odd cell width from 11 up to 27,
and read the dimension from the crossword data.